### PR TITLE
[Fixed] typo in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 To install, run:
 
 ```bash
-$ pip install -e git+https://github.com/sabpereira/github-auto-release.git#egg=github-auto-release
+$ pip install -e git+https://github.com/belvo-finance/github-auto-release.git#egg=github-auto-release
 ```
 
 <!---


### PR DESCRIPTION
We are now using our own fork for the release process.
This was referencing to the original repo.