### PR TITLE
[Fixed][BEL-16266] GitHub auto release not installing properly on mac python 3 10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyGithub~=1.45
 semver~=2.9.0
-click~=7.0
+click~=8.0
 colorama~=0.4.3
 emoji~=0.5.4

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     name="github-auto-release",
     version="beta",
     python_requires=">=3.5, <4",
+    py_modules=[],
     install_requires=requirements,
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
GitHub auto release was not installing properly on mac python 3 10, this should fix it